### PR TITLE
Black Duck: Upgrade underscore to version 1.13.2 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "strip-bom": "^3.0.0",
     "stripe": "^5.10.0",
     "uglifycss": "0.0.27",
-    "underscore": "^1.9.1"
+    "underscore": "^1.13.2"
   },
   "devDependencies": {
     "ava": "^2.4.0",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade underscore from version 1.9.1 to 1.13.2 in order to fix security vulnerabilities:

The direct dependency underscore/1.9.1 has 1 vulnerabilities (max score 7.3).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | underscore/1.9.1 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-1143/overview" target="_blank">BDSA-2021-1143</a> | <span style="color:Red">7.3</span> | Old and Insecure Components | The Underscore Javascript library contains an arbitrary code execution vulnerability.  This allows an attacker to create malicious content that, if processed by Underscore may lead to the execution of | 1.9.1 |


