### PR TITLE
Black Duck: Upgrade eslint-plugin-import to version 2.25.4 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ava": "^2.4.0",
     "eslint": "^6.6.0",
     "eslint-config-standard": "^13.0.1",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade eslint-plugin-import from version 2.18.2 to 2.25.4 in order to fix security vulnerabilities:

The direct dependency eslint-plugin-import/2.18.2 has 2 vulnerabilities in child dependencies (max score 6.7).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| eslint-plugin-import/2.18.2 | path-parse/1.0.5 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-2284/overview" target="_blank">BDSA-2021-2284</a> | <span style="color:Orange">6.7</span> | Old and Insecure Components | path-parse contains a vulnerability to regular expression denial of service (ReDoS). An attacker could exploit this vulnerability by supplying a maliciously crafted input to consume the application's  | 1.0.5 |
| eslint-plugin-import/2.18.2 | hosted-git-info/2.5.0 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-4571/overview" target="_blank">BDSA-2020-4571</a> | <span style="color:Orange">6.7</span> | Old and Insecure Components | hosted-git-info is vulnerable to regular expression denial of service (ReDoS) via `fromUrl()`. An attacker could exploit this vulnerability by supplying a maliciously crafted input to consume resource | 2.5.0 |


