### PR TITLE
Black Duck: Upgrade axios to version 0.25.0 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "ajv": "^6.10.2",
     "async": "^2.6.3",
-    "axios": "^0.19.0",
+    "axios": "^0.25.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "cheerio": "^0.22.0",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade axios from version 0.19.0 to 0.25.0 in order to fix security vulnerabilities:

The direct dependency axios/0.19.0 has 2 vulnerabilities (max score 7.8) and 1 vulnerabilities in child dependencies (max score 6.5).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | axios/0.19.0 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-3243/overview" target="_blank">BDSA-2020-3243</a> | <span style="color:Red">7.8</span> | Old and Insecure Components | It was found that axios could allow for server side request forgery (SSRF) attacks if it is used to pass user-supplied URL requests via a proxy. This vulnerability could be used to bypass the proxy th | 0.19.0 |
| / | axios/0.19.0 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/CVE-2021-3749/overview" target="_blank">CVE-2021-3749</a> | <span style="color:Red">7.5</span> | Old and Insecure Components | axios is vulnerable to Inefficient Regular Expression Complexity | 0.19.0 |
| axios/0.19.0 | follow-redirects/1.5.10 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/CVE-2022-0155/overview" target="_blank">CVE-2022-0155</a> | <span style="color:Orange">6.5</span> | Old and Insecure Components | follow-redirects is vulnerable to Exposure of Private Personal Information to an Unauthorized Actor | 1.5.10 |


