### PR TITLE
Black Duck: Upgrade mongodb to version 3.7.3 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mime-type": "^3.0.7",
     "mkdirp": "^0.5.1",
     "moment": "^2.24.0",
-    "mongodb": "^3.3.3",
+    "mongodb": "^3.7.3",
     "mongodb-uri": "^0.9.7",
     "morgan": "^1.9.1",
     "multer": "^1.4.2",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade mongodb from version 3.3.3 to 3.7.3 in order to fix security vulnerabilities:

The direct dependency mongodb/3.3.3 has 1 vulnerabilities in child dependencies (max score 7.9).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| mongodb/3.3.3 | bson/1.1.1 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-0604/overview" target="_blank">BDSA-2020-0604</a> | <span style="color:Red">7.9</span> | Old and Insecure Components | Bson contains a deserialization of untrusted data vulnerability due to improper handling of user input. An attacker could exploit this vulnerability through specially crafted input which could lead to | 1.1.1 |


