### PR TITLE
Black Duck: Upgrade ajv to version 6.12.6 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": "10.16.0"
   },
   "dependencies": {
-    "ajv": "^6.10.2",
+    "ajv": "^6.12.6",
     "async": "^2.6.3",
     "axios": "^0.19.0",
     "bcryptjs": "^2.4.3",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade ajv from version 6.10.2 to 6.12.6 in order to fix security vulnerabilities:

The direct dependency ajv/6.10.2 has 1 vulnerabilities (max score 7.1).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | ajv/6.10.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-3798/overview" target="_blank">BDSA-2020-3798</a> | <span style="color:Red">7.1</span> | Old and Insecure Components | nodejs-ajv is vulnerable to a prototype pollution flaw. A remote attacker could leverage this to execute arbitrary code. | 6.10.2 |


