### PR TITLE
Black Duck: Upgrade mkdirp to version 0.5.5 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.15",
     "lunr": "^2.3.8",
     "mime-type": "^3.0.7",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.5",
     "moment": "^2.24.0",
     "mongodb": "^3.3.3",
     "mongodb-uri": "^0.9.7",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade mkdirp from version 0.5.1 to 0.5.5 in order to fix security vulnerabilities:

The direct dependency mkdirp/0.5.1 has 1 vulnerabilities in child dependencies (max score 7.3).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| mkdirp/0.5.1 | minimist/0.0.8 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-4373/overview" target="_blank">BDSA-2020-4373</a> | <span style="color:Red">7.3</span> | Old and Insecure Components | minimist is vulnerable to a prototype pollution attack. A remote attacker may be able to execute arbitrary code, or cause a denial-of-service (DoS) by tricking the library into modifying or adding pro | 0.0.8 |


