### PR TITLE
Black Duck: Upgrade connect-mongodb-session to version 2.4.1 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "body-parser": "^1.19.0",
     "cheerio": "^0.22.0",
     "colors": "^1.4.0",
-    "connect-mongodb-session": "^2.2.0",
+    "connect-mongodb-session": "^2.4.1",
     "cookie-parser": "^1.4.4",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
@@ -93,4 +93,3 @@
     "url": "https://github.com/mrvautin/expressCart/issues"
   }
 }
-


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade connect-mongodb-session from version 2.2.0 to 2.4.1 in order to fix security vulnerabilities:

The direct dependency connect-mongodb-session/2.2.0 has 2 vulnerabilities in child dependencies (max score 7.9).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| connect-mongodb-session/2.2.0 | mpath/0.5.1 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-2895/overview" target="_blank">BDSA-2021-2895</a> | <span style="color:Orange">6.6</span> | Old and Insecure Components | mpath is vulnerable to prototype pollution due to the existence of a type confusion flaw. A remote attacker could modify the properties of an object by sending maliciously crafted requests to a vulner | 0.5.1 |
| connect-mongodb-session/2.2.0 | bson/1.1.1 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-0604/overview" target="_blank">BDSA-2020-0604</a> | <span style="color:Red">7.9</span> | Old and Insecure Components | Bson contains a deserialization of untrusted data vulnerability due to improper handling of user input. An attacker could exploit this vulnerability through specially crafted input which could lead to | 1.1.1 |


